### PR TITLE
Corrigido o problema de duplicidade de motivo-vendas

### DIFF
--- a/models/marts/dim_motivovendas.sql
+++ b/models/marts/dim_motivovendas.sql
@@ -7,17 +7,45 @@ with
         from {{ ref('stg_sap_motivovendas') }}
     )
 
+    , crossmotivos as (
+        select 
+            fk_id_pedido as id_pedido				
+            , fk_id_motivovenda as id_motivovenda
+        from {{ ref('stg_sap_crosspedidomotivos') }}
+    )
+
+    , pedidos as (
+        select 
+            pk_id_pedido
+            
+        from {{ ref('stg_sap_pedidos') }}
+    )
+
+    , join_tabelas as (
+        select 
+            pedidos.pk_id_pedido as id_pedido
+            , string_agg(motivovendas.motivo, '; ') as motivo
+        from pedidos
+        left join crossmotivos on pedidos.pk_id_pedido = crossmotivos.id_pedido
+        left join motivovendas on crossmotivos.id_motivovenda = motivovendas.pk_id_motivovenda
+        group by pedidos.pk_id_pedido
+    )
+
     , transformacoes as (
         select
             {{
                 dbt_utils.generate_surrogate_key(
-                    ["pk_id_motivovenda"]
+                    ["id_pedido"]
                 )
             }} as sk_motivovenda
             , *
-        from motivovendas
+        from join_tabelas
 
     )
 
-select *
+select distinct 
+    sk_motivovenda
+    , id_pedido
+    , motivo
 from transformacoes
+--limit 32000

--- a/models/marts/dim_motivovendas_old.sql
+++ b/models/marts/dim_motivovendas_old.sql
@@ -1,0 +1,23 @@
+
+with
+    motivovendas as (
+        select 
+            pk_id_motivovenda
+            , motivo
+        from {{ ref('stg_sap_motivovendas') }}
+    )
+
+    , transformacoes as (
+        select
+            {{
+                dbt_utils.generate_surrogate_key(
+                    ["pk_id_motivovenda"]
+                )
+            }} as sk_motivovenda
+            , *
+        from motivovendas
+
+    )
+
+select *
+from transformacoes

--- a/models/marts/fct_vendas_old.sql
+++ b/models/marts/fct_vendas_old.sql
@@ -40,17 +40,16 @@ with
     , motivos as (
         select
             sk_motivovenda
-            , id_pedido
-            , motivo
+            , pk_id_motivovenda as id_motivovenda
         from {{ ref('dim_motivovendas') }}
     )
 
-    --, crossmotivos as (
-    --    select 
-    --        fk_id_pedido as id_pedido				
-    --        , fk_id_motivovenda as id_motivovenda
-    --    from {{ ref('stg_sap_crosspedidomotivos') }}
-    --)
+    , crossmotivos as (
+        select 
+            fk_id_pedido as id_pedido				
+            , fk_id_motivovenda as id_motivovenda
+        from {{ ref('stg_sap_crosspedidomotivos') }}
+    )
 
     , enderecos as (
         select 
@@ -81,22 +80,21 @@ with
             , pedidos.data_envio					
             , pedidos.status_pedido					
             , pedidos.ordem_compra					
-            , pedidos.numero_conta_financeiro
-            --, motivos.motivo	
+            , pedidos.numero_conta_financeiro	
                         
         from pedidos
         left join clientes on pedidos.id_cliente = clientes.id_cliente
         left join enderecos on pedidos.id_endereco = enderecos.id_endereco
         left join produtos on pedidos.id_produto = produtos.id_produto
-        --left join crossmotivos on pedidos.id_pedido = crossmotivos.id_pedido
-        left join motivos on pedidos.id_pedido = motivos.id_pedido
+        left join crossmotivos on pedidos.id_pedido = crossmotivos.id_pedido
+        left join motivos on crossmotivos.id_motivovenda = motivos.id_motivovenda
         left join cartoes on pedidos.id_cartao = cartoes.id_cartao
 
     )
 
     , transformacoes as (
         select 
-            {{ dbt_utils.generate_surrogate_key(['pk_pedido', 'fk_produto']) }} as sk_venda
+            {{ dbt_utils.generate_surrogate_key(['pk_pedido', 'fk_produto', 'fk_motivovenda']) }} as sk_venda
             , *
 
         from join_tabelas
@@ -104,4 +102,3 @@ with
 
 select *
 from transformacoes
---limit 200000

--- a/models/marts/total_produtos_vendidos.sql
+++ b/models/marts/total_produtos_vendidos.sql
@@ -10,4 +10,5 @@ with
 select total_produto
 from vendas
 
--- 136.309
+-- 131788 valor original do SAP
+-- 136.309 duplicidade motivo vendas

--- a/tests/protudos_vendidos.sql
+++ b/tests/protudos_vendidos.sql
@@ -12,5 +12,7 @@ with
     )
 select total_produto
 from vendas
-where total_produto != 136309
+where total_produto != 131788
+
+-- 136309 valor devido duplicidade motivo-vendas por item pedido
 


### PR DESCRIPTION
Utilizei função de agregação para corrigir a duplicidade de motivo de vendas. 
Mantive as versões antigas das dimensões (old).